### PR TITLE
 Set-Cookie response headers information

### DIFF
--- a/source/includes/cocart-v1/_cookie.md
+++ b/source/includes/cocart-v1/_cookie.md
@@ -17,3 +17,10 @@ If the framework your using is not able to read the cookie, then there are a few
 
 1. Look for a cookie support add-on for your framework. React for example has one called [react-cookies](https://www.npmjs.com/package/react-cookies).
 2. Read the cookie value yourself and explode it by `||` and get the first key value. Once you have that value you can use it to set the `cart_key` parameter on all API requests. This will use the [Set Cart ID Method](#cart-guest-customers-set-cart-id-method).
+
+## Note about response Set-Cookie-headers ##
+The cookies for Woocommerce and therefore the cart key is supplied through response headers, so called [Set-Cookie-headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).
+
+Cookies received via Set-Cookie-headers is stored in the browser for the domain upon which holds the API, meaning you can encounter problems reading the cookie values from your frontend.
+
+If using a package like [axios](https://github.com/axios/axios), make sure to supply the correct config parameters that enables cookies in requests to the server. As an example, axios has a config parameter called `withAuthorization`. With the flag set to true, cookies previous set will be sent in the request.

--- a/source/includes/cocart-v1/_cookie.md
+++ b/source/includes/cocart-v1/_cookie.md
@@ -19,11 +19,11 @@ If the framework your using is not able to read the cookie, then there are a few
 2. Read the cookie value yourself and explode it by `||` and get the first key value. Once you have that value you can use it to set the `cart_key` parameter on all API requests. This will use the [Set Cart ID Method](#cart-guest-customers-set-cart-id-method).
 
 ## Note about response Set-Cookie-headers ##
-The cookies for Woocommerce and therefore the cart key is supplied through response headers, so called [Set-Cookie-headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).
+The cookie for CoCart and therefore the cart key is supplied through response headers, so called [Set-Cookie-headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie).
 
 Cookies received via Set-Cookie-headers is stored in the browser for the domain upon which holds the API, meaning you can encounter problems reading the cookie values from your frontend.
 
 If using a package like [axios](https://github.com/axios/axios), make sure to supply the correct config parameters that enables cookies in requests to the server. As an example, axios has a config parameter called `withAuthorization`. With the flag set to true, cookies previous set will be sent in the request.
 
 ### Cart key in the response payload ###
-Sometimes you need to avoid cookies. It's possible to return the cart key when using the `get_cart`-endpoint. Simply download and activate the [Get Cart Enhanced-plugin](https://wordpress.org/plugins/cocart-get-cart-enhanced/) and you're good-to-go.
+Sometimes you need to avoid cookies. It's possible to return the cart key when using the `wp-json/cocart/v1/get-cart`-endpoint. Simply download and activate the [Get Cart Enhanced add-on plugin](https://wordpress.org/plugins/cocart-get-cart-enhanced/) and you're good-to-go.

--- a/source/includes/cocart-v1/_cookie.md
+++ b/source/includes/cocart-v1/_cookie.md
@@ -24,3 +24,6 @@ The cookies for Woocommerce and therefore the cart key is supplied through respo
 Cookies received via Set-Cookie-headers is stored in the browser for the domain upon which holds the API, meaning you can encounter problems reading the cookie values from your frontend.
 
 If using a package like [axios](https://github.com/axios/axios), make sure to supply the correct config parameters that enables cookies in requests to the server. As an example, axios has a config parameter called `withAuthorization`. With the flag set to true, cookies previous set will be sent in the request.
+
+### Cart key in the response payload ###
+Sometimes you need to avoid cookies. It's possible to return the cart key when using the `get_cart`-endpoint. Simply download and activate the [Get Cart Enhanced-plugin](https://wordpress.org/plugins/cocart-get-cart-enhanced/) and you're good-to-go.


### PR DESCRIPTION
Added some information about set-cookie headers returned in requests, the Woocommerce session cookie and how to encounter issues with third-party libraries such as axios.